### PR TITLE
Adding object extraction by @gsuberland

### DIFF
--- a/DumpMiner/App.xaml.cs
+++ b/DumpMiner/App.xaml.cs
@@ -15,7 +15,7 @@ namespace DumpMiner
     public partial class App : Application
     {
         public static CompositionContainer Container { get; set; }
-        public static string AttachedTo { get; internal set; }
+        internal static IDialogService Dialog { get; private set; }
 
         private static IViewModelLoader _viewModelLoader;
 
@@ -39,6 +39,8 @@ namespace DumpMiner
             _viewModelLoader = Container.GetExport<MefViewModelLoader>().Value;
 
             LoadAppearanceSettings();
+
+            Dialog = App.Container.GetExport<IDialogService>().Value;
 
             DebuggerSession.Instance.OnDetach += OnDetach;
         }

--- a/DumpMiner/Common/IDebuggerSession.cs
+++ b/DumpMiner/Common/IDebuggerSession.cs
@@ -17,7 +17,8 @@ namespace DumpMiner.Common
         DataTarget DataTarget { get; }
         ClrRuntime Runtime { get; }
         ClrHeap Heap { get; }
-        DateTime AttachedTime { get; }
+        DateTime? AttachedTime { get; }
         Task<IEnumerable<object>> ExecuteOperation(Func<IEnumerable<object>> operation);
+        (int? id, string name) AttachedTo { get; }
     }
 }

--- a/DumpMiner/Common/IDialogService.cs
+++ b/DumpMiner/Common/IDialogService.cs
@@ -1,7 +1,9 @@
-﻿namespace DumpMiner.Common
+﻿using System.Windows;
+
+namespace DumpMiner.Common
 {
     interface IDialogService
     {
-        void ShowDialog(string text);
+        MessageBoxResult ShowDialog(string text, string title = "", MessageBoxButton button = MessageBoxButton.OK);
     }
 }

--- a/DumpMiner/Common/OperationNames.cs
+++ b/DumpMiner/Common/OperationNames.cs
@@ -24,5 +24,6 @@
         public const string DumpSyncBlock = "DumpSyncBlock";
         public const string TypeFromHandle = "TypeFromHandle";
         public const string DumpSourceCode = "DumpSourceCodeOperation";
+        public const string DumpObjectToDisk = "DumpObjectToDiscOperation";
     }
 }

--- a/DumpMiner/DumpMiner.csproj
+++ b/DumpMiner/DumpMiner.csproj
@@ -44,6 +44,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <PlatformTarget>x64</PlatformTarget>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -52,6 +53,7 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
     <DebugSymbols>true</DebugSymbols>
@@ -62,6 +64,7 @@
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
     <Prefer32Bit>true</Prefer32Bit>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
     <OutputPath>bin\x64\Release\</OutputPath>
@@ -72,6 +75,7 @@
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
     <Prefer32Bit>true</Prefer32Bit>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">
     <DebugSymbols>true</DebugSymbols>
@@ -82,6 +86,7 @@
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
     <Prefer32Bit>true</Prefer32Bit>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x86'">
     <OutputPath>bin\x86\Release\</OutputPath>
@@ -92,6 +97,7 @@
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
     <Prefer32Bit>true</Prefer32Bit>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <PropertyGroup>
     <ApplicationIcon>digg.ico</ApplicationIcon>
@@ -312,6 +318,9 @@
     <Compile Include="Common\IDialogService.cs" />
     <Compile Include="Models\GeneralDebugInfoModel.cs" />
     <Compile Include="Models\OperationModel.cs" />
+    <Compile Include="ObjectExtractors\BitmapExtractor.cs" />
+    <Compile Include="ObjectExtractors\IObjectExtractor.cs" />
+    <Compile Include="ObjectExtractors\ObjectExtraction.cs" />
     <Compile Include="Operations\DumpExceptionsOperation.cs" />
     <Compile Include="Operations\DumpClrStackOperation.cs" />
     <Compile Include="Operations\DumpGcHandlesOperation.cs" />
@@ -324,6 +333,7 @@
     <Compile Include="Operations\DumpFinalizerQueueOperation.cs" />
     <Compile Include="Operations\DumpDelegateMethodOperation.cs" />
     <Compile Include="Operations\DumpArrayItemOperation.cs" />
+    <Compile Include="Operations\DumpObjectToDiskOperation.cs" />
     <Compile Include="Operations\DumpSourceCodeOperation.cs" />
     <Compile Include="Operations\DumpTypeInfoOperation.cs" />
     <Compile Include="Operations\DumpSyncBlockOperation.cs" />

--- a/DumpMiner/Infrastructure/UI/Controls/OperationView.xaml
+++ b/DumpMiner/Infrastructure/UI/Controls/OperationView.xaml
@@ -112,7 +112,13 @@
 
                 <ListView Grid.Column="0" Grid.RowSpan="3" Name="ItemsList" SelectionChanged="ItemsList_OnSelectionChanged"
                           ItemsSource="{Binding Items}"
-                          SelectedItem="{Binding SelectedItem}" />
+                          SelectedItem="{Binding SelectedItem}" >
+                    <ListView.ContextMenu>
+                        <ContextMenu>
+                            <MenuItem Header="Dump to file..." Click="DumpMenuClicked" CommandParameter="{Binding RelativeSource={RelativeSource Self}, Path=Parent}" />
+                        </ContextMenu>
+                    </ListView.ContextMenu>
+                </ListView>
 
                 <ItemsControl HorizontalAlignment="Stretch"
                               Grid.Row="0" Grid.Column="1"

--- a/DumpMiner/Infrastructure/UI/DialogService.cs
+++ b/DumpMiner/Infrastructure/UI/DialogService.cs
@@ -8,10 +8,21 @@ namespace DumpMiner.Infrastructure.UI
     [Export(typeof(IDialogService))]
     class DialogService : IDialogService
     {
-        public void ShowDialog(string text)
+        public MessageBoxResult ShowDialog(string text, string title = "", MessageBoxButton button = MessageBoxButton.OK)
         {
-            if (Application.Current != null)
-                ModernDialog.ShowMessage(text, string.Empty, MessageBoxButton.OK, Application.Current.MainWindow);
+            if (Application.Current.Dispatcher.CheckAccess())
+            {
+                return Application.Current == null
+                    ? MessageBoxResult.Cancel
+                    : ModernDialog.ShowMessage(text, string.Empty, MessageBoxButton.OK, Application.Current.MainWindow);
+            }
+            else
+            {
+                return Application.Current.Dispatcher.Invoke(() => Application.Current == null
+                    ? MessageBoxResult.Cancel
+                    : ModernDialog.ShowMessage(text, string.Empty, MessageBoxButton.OK,
+                        Application.Current.MainWindow));
+            }
         }
     }
 }

--- a/DumpMiner/ObjectExtractors/BitmapExtractor.cs
+++ b/DumpMiner/ObjectExtractors/BitmapExtractor.cs
@@ -1,0 +1,318 @@
+﻿using DumpMiner.Debugger;
+using Microsoft.Diagnostics.Runtime;
+using System;
+using System.Drawing;
+using System.Drawing.Imaging;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace DumpMiner.ObjectExtractors
+{
+    class BitmapExtractor : IObjectExtractor
+    {
+        public string GetFileNameSuffix()
+        {
+            return "_bitmap.bmp";
+        }
+
+        private ulong? ReadPointer(ulong address)
+        {
+            byte[] buffer = new byte[DebuggerSession.Instance.DataTarget.PointerSize];
+
+            if (!DebuggerSession.Instance.DataTarget.ReadProcessMemory(address, buffer, buffer.Length, out var br))
+            {
+                return null;
+            }
+
+            if (br != buffer.Length)
+            {
+                return null;
+            }
+
+            ulong addr = buffer.Length == 4
+                ? BitConverter.ToUInt32(buffer, 0)
+                : BitConverter.ToUInt64(buffer, 0);
+
+            return addr;
+        }
+
+        private uint? ReadDWORD(ulong address)
+        {
+            byte[] buffer = new byte[4];
+
+            if (!DebuggerSession.Instance.DataTarget.ReadProcessMemory(address, buffer, buffer.Length, out var br))
+            {
+                return null;
+            }
+
+            if (br != buffer.Length)
+            {
+                return null;
+            }
+
+            return BitConverter.ToUInt32(buffer, 0);
+        }
+
+        public Task<bool> Extract(string path, ulong address, ulong size, string typeName)
+        {
+            try
+            {
+                // only support 32-bit images for now
+                if (DebuggerSession.Instance.DataTarget.PointerSize != 4)
+                {
+                    App.Dialog.ShowDialog("Only 32-bit targets are currently supported for bitmap extraction.", title: "Error");
+                    return Task.FromResult(false);
+                }
+
+                // get the type at the target address, so we can read the fields
+                var heap = DebuggerSession.Instance.Runtime.Heap;
+                ClrType type = heap.GetObjectType(address);
+                if (type == null)
+                {
+                    return Task.FromResult(false);
+                }
+
+                // get the nativeImage field. this points to a native gdiplus!GpBitmap object.
+                var nativeBitmapField = type.GetFieldByName("nativeImage");
+                if (nativeBitmapField == null)
+                {
+                    return Task.FromResult(false);
+                }
+
+                /*
+                 * We're going to try to get to a gdiplus!GpMemoryBitmap object from here.
+                 * The overall path is: GpBitmap -> CopyOnWriteBitmap -> GpMemoryBitmap -> Raw pixel data
+                 * 
+                 * Values given here are for 32-bit. I need to figure this out for 64-bit yet.
+                 * 
+                 * These structures are undocumented and their fields are no longer included in PDBs for gdiplus. I'm having to go from old struct dumps from a random MSDN post:
+                 * https://social.msdn.microsoft.com/Forums/en-US/cd86ddf7-da4b-4b85-a737-b516dbb13d03/windows-form-application-use-a-huge-amount-of-memory-in-vista-but-not-in-xp?forum=winforms
+                 * 
+                 * GpBitmap looks like this:
+                 *  +0x00 void* VTablePtr;
+                 *  +0x04 DWORD Tag; // should equal 0x676d4931, i.e. ObjectTagImage
+                 *  +0x08 DWORD Uid; // usually 0
+                 *  +0x0c DWORD ImgType; // should equal 1, i.e. ImageTypeBitmap
+                 *  +0x10 DWORD Lockable; // usually 0xffffffff
+                 *  +0x14 CopyOnWriteBitmap* InternalBitmap; // <------ THIS IS THE POINTER WE NEED
+                 *  +0x16 DWORD ScanBitmapRef; // usually 1, no idea what this does
+                 *  +0x16 EpScanBitmap ScanBitmap; // not a pointer, this struct follows immediately on (it also starts with a vtable pointer)
+                 * 
+                 * CopyOnWriteBitmap looks like this:
+                 *  +0x00 void* VTablePtr;
+                 *  +0x04 DWORD RefCount; // should never be zero.
+                 *  +0x08 _RTL_CRITICAL_SECTION Semaphore; // usually starts with two 0xffffffff DWORDs.
+                 *  +0x20 DWORD State; // usually 4
+                 *  +0x24 DWORD ObjRefCount; // should never be zero
+                 *  +0x28 WCHAR* FileName; // contains the path to the file
+                 *  +0x2c void* FileStream; // points to a filestream object if you opened the image from a stream and the stream stil exists
+                 *  +0x30 void* Img; // not entire sure what this is? appears to be populated if you open a jpeg/png/whatever so probably used for decoding
+                 *  +0x34 GdMemoryBitmap* Bmp; // <------ THIS IS THE POINTER WE NEED
+                 *  +0x38 DWORD CurrentFrameIndex; // animated gifs
+                 *  +0x3c void* CleanupBitmapData; // no idea
+                 *  +0x40 void* EncoderPtr; // related to png/jpeg/whatever encoding
+                 *  +0x44 DWORD SpecialJPEGSave; // some flag, probably a BOOL. usually 0
+                 *  +0x48 DWORD ICMConvert; // probably a BOOL, usually 0, set 1 if ICM profile is to be saved when the image is saved
+                 *  +0x4c DWORD Display; // might be a BOOL? set to 1 in every case I've seen
+                 *  +0x50 DWORD XDpiOverride; // probably a BOOL that tells it to not do DPI scaling horizontally
+                 *  +0x54 DWORD YDpiOverride; // same again, vertically
+                 *  +0x58 DWORD DirtyFlag; // probably a BOOL, probably set whenever a change has been made after load
+                 *  ... a bunch more random stuff
+                 *  +0xa0 DWORD PixelFormatInMem;   // useful because this _may_ differ from what the bitmap's pixel format is, but I think this gets repeated in GpMemoryBitmap anyway
+                 *                                  // these are gdiplus pixel format values. see https://github.com/VFPX/CodePlex/blob/master/VFP9/Ffc/gdiplus.h#L377 and https://vfpimaging.blogspot.com/2006/03/drawing-on-gifs-or-indexed-pixel-format_3176.html
+                 *  ... more fields of little use
+                 *  
+                 *  GpMemoryBitmap looks like this:
+                 *   +0x00 void* VTablePtr0; // four pointers into gdiplus!GpMemoryBitmap::`vftable'.
+                 *   +0x04 void* VTablePtr1; // these aren't all equal but they should be within 0x200 of each other in total
+                 *   +0x08 void* VTablePtr2;
+                 *   +0x0c void* VTablePtr3;
+                 *   +0x10 DWORD Width; // width of the image in pixels
+                 *   +0x14 DWORD Height; // height of the image in pixels
+                 *   +0x18 DWORD Stride; // number of bytes that each line takes up in memory. this is usually Width multiplied by how many bytes per pixel are used, *BUT* there may be padding at the end of each row!
+                 *   +0x1c DWORD PixelFormat; // pixel format for the data. should be the canonical pixel format to use here. see links above for values (0x0026200A for 32bpp ARGB is common)
+                 *   +0x20 void* Scan0; // <----- THIS IS THE POINTER WE NEED. it points to the pixel buffer
+                 *   +0x24 DWORD Reserved; // seems to always be set to 0x20000
+                 *   +0x28 DWORD ComRefCount; // should be at least 1 
+                 *   +0x2c DWORD ObjectLock; // usually 0xffffffff
+                 *   ... fields after this don't quite match ref I could find, so I think this has been modified a bunch
+                 * 
+                 */
+
+                // read Bitmap->nativeBitmap
+                object nativeBitmapValue = nativeBitmapField.GetValue(address);
+                long nativeBitmapAddrLong = (long)nativeBitmapValue;
+                ulong nativeBitmapAddr = Convert.ToUInt64(nativeBitmapAddrLong);
+                if (nativeBitmapAddr == 0)
+                {
+                    return Task.FromResult(false);
+                }
+
+                // read GpBitmap->Tag and validate
+                const UInt32 ObjectTagImage = 0x676d4931;
+                var gpBitmap_Tag = ReadDWORD(nativeBitmapAddr + 0x04ul);
+                if ((gpBitmap_Tag ?? 0) != ObjectTagImage)
+                {
+                    return Task.FromResult(false);
+                }
+
+                // read GpBitmap->InternalBitmap
+                var copyOnWriteBitmapAddr = ReadPointer(nativeBitmapAddr + 0x14ul);
+                if ((copyOnWriteBitmapAddr ?? 0) == 0)
+                {
+                    return Task.FromResult(false);
+                }
+
+                // read CopyOnWriteBitmap->RefCount and validate
+                var copyOnWriteBitmap_RefCount = ReadDWORD(copyOnWriteBitmapAddr.Value + 0x04ul);
+                if ((copyOnWriteBitmap_RefCount ?? 0) == 0)
+                {
+                    return Task.FromResult(false);
+                }
+
+                // read CopyOnWriteBitmap->Bmp
+                var gpMemoryBitmapAddr = ReadPointer(copyOnWriteBitmapAddr.Value + 0x34ul);
+                if ((gpMemoryBitmapAddr ?? 0) == 0)
+                {
+                    // if this is null, it might be a decoded image that was loaded from disk
+                    // unfortunately I haven't figured out how to get image data from this struct, but I can at least report the filename if it's there
+
+                    // read CopyOnWriteBitmap->Img
+                    var copyOnWriteBitmap_ImgAddr = ReadPointer(copyOnWriteBitmapAddr.Value + 0x30ul);
+                    if ((copyOnWriteBitmap_ImgAddr ?? 0) == 0)
+                    {
+                        // no idea what's happening here, just fail
+                        return Task.FromResult(false);
+                    }
+
+                    // ok, looks like we got an image that was loaded via an encoder. try to grab the path
+                    var copyOnWriteBitmap_FilePathAddr = ReadPointer(copyOnWriteBitmapAddr.Value + 0x28);
+                    if ((copyOnWriteBitmap_FilePathAddr ?? 0) == 0)
+                    {
+                        return Task.FromResult(false);
+                    }
+
+                    // we got a file path. read it.
+                    byte[] filePathBuffer = new byte[1024];
+                    if (!DebuggerSession.Instance.DataTarget.ReadProcessMemory(copyOnWriteBitmap_FilePathAddr.Value,
+                            filePathBuffer, 1024, out var br))
+                    {
+                        return Task.FromResult(false);
+                    }
+
+                    if (br < 4)
+                    {
+                        return Task.FromResult(false);
+                    }
+
+                    string bitmapPath = Encoding.Unicode.GetString(filePathBuffer, 0, br);
+                    App.Dialog.ShowDialog("This bitmap was not generated by the program, but was instead loaded from a file. The in-memory structures for this are not well understood, however a file path was recovered:\n\n" + bitmapPath, "Image file path");
+                    return Task.FromResult(false);
+                }
+
+                // read GpMemoryBitmap->VTablePtr0 to GpMemoryBitmap->VTablePtr3, and validate
+                var gpMemoryBitmap_VTablePtr0 = ReadPointer(gpMemoryBitmapAddr.Value);
+                var gpMemoryBitmap_VTablePtr1 = ReadPointer(gpMemoryBitmapAddr.Value + 0x04ul);
+                var gpMemoryBitmap_VTablePtr2 = ReadPointer(gpMemoryBitmapAddr.Value + 0x08ul);
+                var gpMemoryBitmap_VTablePtr3 = ReadPointer(gpMemoryBitmapAddr.Value + 0x0cul);
+                if ((gpMemoryBitmap_VTablePtr0 ?? 0) == 0 ||
+                    (gpMemoryBitmap_VTablePtr1 ?? 0) == 0 ||
+                    (gpMemoryBitmap_VTablePtr2 ?? 0) == 0 ||
+                    (gpMemoryBitmap_VTablePtr3 ?? 0) == 0)
+                {
+                    return Task.FromResult(false);
+                }
+
+                ulong maxAddr = gpMemoryBitmap_VTablePtr0.Value;
+                ulong minAddr = gpMemoryBitmap_VTablePtr0.Value;
+                maxAddr = Math.Max(maxAddr, gpMemoryBitmap_VTablePtr1.Value);
+                maxAddr = Math.Max(maxAddr, gpMemoryBitmap_VTablePtr2.Value);
+                maxAddr = Math.Max(maxAddr, gpMemoryBitmap_VTablePtr3.Value);
+                minAddr = Math.Min(maxAddr, gpMemoryBitmap_VTablePtr1.Value);
+                minAddr = Math.Min(maxAddr, gpMemoryBitmap_VTablePtr2.Value);
+                minAddr = Math.Min(maxAddr, gpMemoryBitmap_VTablePtr3.Value);
+                if (maxAddr - minAddr > 0x400) // should be within 0x200 of each other, but let's expand that to 0x400 for safety
+                {
+                    return Task.FromResult(false);
+                }
+
+                // read width, height, stride, pixel format
+                var gpMemoryBitmap_Width = ReadDWORD(gpMemoryBitmapAddr.Value + 0x10ul);
+                if ((gpMemoryBitmap_Width ?? 0) == 0 || (gpMemoryBitmap_Width ?? 0) > 65535)
+                {
+                    return Task.FromResult(false);
+                }
+
+                var gpMemoryBitmap_Height = ReadDWORD(gpMemoryBitmapAddr.Value + 0x14ul);
+                if ((gpMemoryBitmap_Height ?? 0) == 0 || (gpMemoryBitmap_Height ?? 0) > 65535)
+                {
+                    return Task.FromResult(false);
+                }
+
+                var gpMemoryBitmap_Stride = ReadDWORD(gpMemoryBitmapAddr.Value + 0x18ul);
+                if ((gpMemoryBitmap_Stride ?? 0) == 0 || (gpMemoryBitmap_Height ?? 0) > (65535 * 8))
+                {
+                    return Task.FromResult(false);
+                }
+
+                var gpMemoryBitmap_PixelFormat = ReadDWORD(gpMemoryBitmapAddr.Value + 0x1cul);
+                if ((gpMemoryBitmap_PixelFormat ?? 0) == 0)
+                {
+                    return Task.FromResult(false);
+                }
+
+                // read GpMemoryBitmap->Scan0
+                var pixelDataAddr = ReadPointer(gpMemoryBitmapAddr.Value + 0x20ul);
+                if ((pixelDataAddr ?? 0) == 0)
+                {
+                    return Task.FromResult(false);
+                }
+
+                // turn the data into a bitmap :)
+                using (var bmp = new Bitmap((int)gpMemoryBitmap_Width, (int)gpMemoryBitmap_Height))
+                {
+                    // the PixelFormat enum uses GDI values so we can just cast directly!
+                    var pixelFormat = (PixelFormat)gpMemoryBitmap_PixelFormat;
+                    var bd = bmp.LockBits(new Rectangle(0, 0, bmp.Width, bmp.Height), ImageLockMode.WriteOnly, pixelFormat);
+
+                    try
+                    {
+                        // apply the stride
+                        bd.Stride = (int)gpMemoryBitmap_Stride.Value;
+
+                        // buffer for storing each line's data
+                        byte[] buffer = new byte[gpMemoryBitmap_Stride.Value];
+                        for (uint y = 0; y < gpMemoryBitmap_Height.Value; y++)
+                        {
+                            ulong lineAddr = pixelDataAddr.Value + (y * gpMemoryBitmap_Stride.Value);
+                            DebuggerSession.Instance.DataTarget.ReadProcessMemory(lineAddr, buffer, (int)gpMemoryBitmap_Stride.Value, out _);
+                            Marshal.Copy(buffer, 0, bd.Scan0 + (int)(y * bd.Stride), (int)gpMemoryBitmap_Stride.Value);
+                        }
+
+                    }
+                    finally
+                    {
+                        bmp.UnlockBits(bd);
+                    }
+
+                    bmp.Save(path, ImageFormat.Bmp);
+                }
+
+                return Task.FromResult(true);
+            }
+            catch (Exception e)
+            {
+                App.Dialog.ShowDialog(e.ToString(), title: "Error");
+                return Task.FromResult(false);
+            }
+
+            //var result = await DebuggerSession.Instance.ExecuteOperation(() =>
+            //{
+
+
+            //    return Array.Empty<object>(); // this is the equivalent of "true" here because of the ExecuteOperation wrapper
+            //});
+        }
+    }
+}

--- a/DumpMiner/ObjectExtractors/IObjectExtractor.cs
+++ b/DumpMiner/ObjectExtractors/IObjectExtractor.cs
@@ -1,0 +1,10 @@
+﻿using System.Threading.Tasks;
+
+namespace DumpMiner.ObjectExtractors
+{
+    interface IObjectExtractor
+    {
+        string GetFileNameSuffix();
+        Task<bool> Extract(string path, ulong address, ulong size, string typeName);
+    }
+}

--- a/DumpMiner/ObjectExtractors/ObjectExtraction.cs
+++ b/DumpMiner/ObjectExtractors/ObjectExtraction.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace DumpMiner.ObjectExtractors
+{
+    static class ObjectExtraction
+    {
+        public static IObjectExtractor FindExtractor(string type)
+        {
+            switch (type)
+            {
+                case "System.Drawing.Bitmap":
+                    return new BitmapExtractor();
+            }
+
+            return null;
+        }
+    }
+}

--- a/DumpMiner/Operations/DumpObjectToDiskOperation.cs
+++ b/DumpMiner/Operations/DumpObjectToDiskOperation.cs
@@ -1,0 +1,145 @@
+﻿using DumpMiner.Common;
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.ComponentModel.Composition;
+using System.Globalization;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using DumpMiner.Models;
+using DumpMiner.Debugger;
+using System.Text;
+using DumpMiner.ObjectExtractors;
+using Microsoft.Win32;
+using System.Windows;
+
+namespace DumpMiner.Operations
+{
+    [Export(OperationNames.DumpObjectToDisk, typeof(IDebuggerOperation))]
+    internal class DumpObjectToDiskOperation : IDebuggerOperation
+    {
+        public string Name => OperationNames.DumpObjectToDisk;
+
+        public async Task<IEnumerable<object>> Execute(OperationModel model, CancellationToken token, object customParameter)
+        {
+            return await DebuggerSession.Instance.ExecuteOperation(() =>
+            {
+                var address = model.ObjectAddress;
+                var typeName = model.Types;
+                var size = (ulong)customParameter
+                    ;
+                if (address == 0)
+                {
+                    App.Dialog.ShowDialog("Selected object address is zero. Cannot dump.", title: "Error");
+                    return null;
+                }
+
+                if (size == 0)
+                {
+                    App.Dialog.ShowDialog("Selected object size is zero. Cannot dump.", title: "Error");
+                    return null;
+                }
+
+                if (size > int.MaxValue)
+                {
+                    App.Dialog.ShowDialog("Selected object size is too large. Cannot dump.", title: "Error");
+                    return null;
+                }
+
+                try
+                {
+                    byte[] buffer = new byte[size];
+                    bool success = DebuggerSession.Instance.DataTarget.ReadProcessMemory(address, buffer, (int)size, out var bytesRead);
+                    if (!success || bytesRead <= 0)
+                    {
+                        App.Dialog.ShowDialog("Could not read process memory.", title: "Error");
+                        return null;
+                    }
+
+                    if ((uint)bytesRead < size)
+                    {
+                        byte[] buffer2 = new byte[bytesRead];
+                        Array.Copy(buffer, buffer2, bytesRead);
+                        buffer = buffer2;
+                    }
+
+                    string baseFileName = $"pid_{DebuggerSession.Instance.AttachedTo.id?.ToString() ?? "none"}_obj_{address:x16}_{bytesRead:x8}";
+
+                    var file = new SaveFileDialog
+                    {
+                        Filter = "All files (*.*)|*.*",
+                        Title = "Choose a file name without extensions",
+                        CheckPathExists = true,
+                        OverwritePrompt = true,
+                        InitialDirectory = Environment.CurrentDirectory,
+                        FileName = baseFileName
+                    };
+
+                    var result = file.ShowDialog();
+                    if (!result.HasValue || !result.Value || string.IsNullOrEmpty(file.FileName))
+                    {
+                        return null;
+                    }
+
+                    var dumpDescription = new StringBuilder();
+                    dumpDescription.AppendLine("DumpMiner object dump");
+                    dumpDescription.AppendLine($"Time: {DateTime.Now.ToString(CultureInfo.CurrentCulture)}");
+                    dumpDescription.AppendLine($"Process ID: {DebuggerSession.Instance.AttachedTo.id?.ToString() ?? "N/A"}");
+                    dumpDescription.AppendLine($"Process Name: {DebuggerSession.Instance.AttachedTo.name ?? "N/A"}");
+                    dumpDescription.AppendLine($"Dumped object type: {typeName}");
+                    dumpDescription.AppendLine($"Dumped object address: 0x{address:x16} ({address})");
+                    dumpDescription.AppendLine($"Dumped object size: 0x{size:x8} ({size})");
+
+                    File.WriteAllBytes(file.FileName + ".bin", buffer);
+                    File.WriteAllText(file.FileName + ".txt", dumpDescription.ToString());
+
+                    App.Dialog.ShowDialog($"Dumped {bytesRead} raw bytes from address 0x{address:x16} to {file.FileName}.bin", title: "Info");
+
+                    var extractor = ObjectExtraction.FindExtractor(typeName);
+                    if (extractor == null)
+                    {
+                        return null;
+                    }
+
+                    if (App.Dialog.ShowDialog($"The type {typeName} can be extracted from memory. Would you like to do this?",
+                            "Extract?", MessageBoxButton.YesNo) != MessageBoxResult.Yes)
+                    {
+                        return null;
+                    }
+
+                    string extractFileName = file.FileName + extractor.GetFileNameSuffix();
+                    success = extractor.Extract(extractFileName, address, size, typeName).ConfigureAwait(false).GetAwaiter().GetResult();
+                    if (success)
+                    {
+                        App.Dialog.ShowDialog($"Extraction completed successfully to {file.FileName}");
+                    }
+                    else
+                    {
+                        App.Dialog.ShowDialog("Extraction failed.", title: "Error");
+                        try
+                        {
+                            File.Delete(extractFileName);
+                        }
+                        catch
+                        {
+                            // ignored
+                        }
+                    }
+
+                }
+                catch (Exception ex)
+                {
+                    App.Dialog.ShowDialog($"An exception occurred while dumping the object: {ex}", title: "Error");
+                }
+
+                return null;
+            });
+        }
+
+        public async Task<string> AskGpt(OperationModel model, Collection<object> items, CancellationToken token, object customParameter)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/DumpMiner/Operations/DumpSourceCodeOperation.cs
+++ b/DumpMiner/Operations/DumpSourceCodeOperation.cs
@@ -8,6 +8,7 @@ using System.Reflection.Metadata.Ecma335;
 using System.Threading;
 using System.Threading.Tasks;
 using DumpMiner.Common;
+using DumpMiner.Debugger;
 using DumpMiner.Models;
 using DumpMiner.Reader;
 using ICSharpCode.Decompiler;
@@ -29,12 +30,13 @@ namespace DumpMiner.Operations
 
         private string GetSourceCode(int metadataToken)
         {
-            var dumpData = new Dump(App.AttachedTo);
+            var dumpPath = DebuggerSession.Instance.AttachedTo.name;
+            var dumpData = new Dump(dumpPath);
             var pathToOutputModules = $"{Environment.CurrentDirectory}\\DumpOutputModules";
             Directory.CreateDirectory(pathToOutputModules);
             Console.WriteLine($"Saving all modules to {pathToOutputModules}");
             dumpData.SaveAllModules(pathToOutputModules, true);
-            var dlls = Directory.EnumerateFiles(pathToOutputModules).Where(f => Path.GetFileNameWithoutExtension(f).Equals(Path.GetFileNameWithoutExtension(App.AttachedTo))).Select(f => new FileInfo(f));
+            var dlls = Directory.EnumerateFiles(pathToOutputModules).Where(f => Path.GetFileNameWithoutExtension(f).Equals(Path.GetFileNameWithoutExtension(dumpPath))).Select(f => new FileInfo(f));
             var settings = new DecompilerSettings();
             settings.ThrowOnAssemblyResolveErrors = false;
             var resolver = new UniversalAssemblyResolver(dlls.First().FullName, false, null);

--- a/DumpMiner/Operations/TargetProcessInfoOperation.cs
+++ b/DumpMiner/Operations/TargetProcessInfoOperation.cs
@@ -34,7 +34,7 @@ namespace DumpMiner.Operations
                 infoModel.Architecture = runtime.DataTarget.Architecture.ToString();
                 infoModel.IsGcServer = runtime.ServerGC;
                 infoModel.HeapCount = runtime.HeapCount;
-                infoModel.CreatedTime = DebuggerSession.Instance.AttachedTime.ToUniversalTime().ToString("G");
+                infoModel.CreatedTime = DebuggerSession.Instance.AttachedTime?.ToUniversalTime().ToString("G");
                 infoModel.PointerSize = runtime.PointerSize;
 
                 var enumerable = from prop in infoModel.GetType().GetProperties()

--- a/DumpMiner/ViewModels/AttachDetachViewModel.cs
+++ b/DumpMiner/ViewModels/AttachDetachViewModel.cs
@@ -169,7 +169,6 @@ namespace DumpMiner.ViewModels
             }
 
             AttachedProcessName = SelectedItem.Name;
-            App.AttachedTo = AttachedProcessName;
             DetachVisibility = Visibility.Visible;
             IsGetProcessesEnabled = false;
             Dispose(true);
@@ -187,6 +186,7 @@ namespace DumpMiner.ViewModels
                 DefaultExt = "dmp",
                 InitialDirectory = Environment.GetFolderPath(Environment.SpecialFolder.MyComputer)
             };
+
             var result = file.ShowDialog();
             if (result.HasValue && result.Value && !string.IsNullOrEmpty(file.FileName))
             {
@@ -195,8 +195,8 @@ namespace DumpMiner.ViewModels
                 {
                     App.Container.GetExport<IDialogService>().Value.ShowDialog("Load dump failed");
                 }
+
                 AttachedProcessName = file.FileName;
-                App.AttachedTo = AttachedProcessName;
                 DetachVisibility = Visibility.Visible;
                 IsGetProcessesEnabled = false;
                 DetachProcessesCommand.OnCanExecuteChanged();


### PR DESCRIPTION
- Added support for dumping raw object data to disk, along with a text file containing metadata
- Added support for custom type extractors during the dumping process
- Added a custom type extractor for bitmaps that either creates a bitmap file or informs the user that the Bitmap object was loaded from disk (and tells them the file path)

**Thanks @gsuberland for this contribution**